### PR TITLE
new workflow to ignore dependabot pulls

### DIFF
--- a/workflow-templates/code-scanning-2021-06-08.properties.json
+++ b/workflow-templates/code-scanning-2021-06-08.properties.json
@@ -1,0 +1,13 @@
+{
+  "name": "General Use Code Scanning Workflow",
+  "description": "This workflow will run GitHub Code Scanning for PRs to master. This workflow will automatically detect scannable languages in your repository and run CodeQL queries against them.",
+  "iconName": "lifeomic",
+  "categories": [
+	  "C#",
+	  "C++",
+	  "Go",
+	  "Java",
+	  "JavaScript",
+	  "Python"	
+  ]
+}

--- a/workflow-templates/code-scanning-2021-06-08.yml
+++ b/workflow-templates/code-scanning-2021-06-08.yml
@@ -1,0 +1,56 @@
+# This workflow is inherited from our internal .github repo at https://github.com/lifeomic/.github/blob/master/workflow-templates/code-scanning-2021-06-08.yml
+# Setting up this workflow on the repository will perform a static scan for security issues using GitHub Code Scanning. 
+# Any findings for a repository can be found under the `Security` tab -> `Code Scanning Alerts`
+name: "CodeQL"
+
+on:
+  push:
+    branches: [master]
+    paths-ignore:
+      - test
+      - tests
+      - '**/test'
+      - '**/tests'
+      - '**/*.test.js'
+      - '**/*.test.ts'
+  pull_request:
+    branches: [master]
+    paths-ignore:
+      - test
+      - tests
+      - '**/test'
+      - '**/tests'
+      - '**/*.test.js'
+      - '**/*.test.ts'
+
+jobs:
+  analyze:
+    if: ${{ !contains(github.ref, 'dependabot') }}
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        config-file: lifeomic/.github/config-files/codeql-config.yml@master  # uses our config file from the lifeomic/.github repo
+        queries: +security-extended  # This will run all queries at https://github.com/github/codeql/:language/ql/src/codeql-suites/:language-security-extended.qls
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, it should be removed and replaced with custom build steps.
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
This should bypass the code scan on PRs with "dependabot" in the branch name. Pull requests created by Dependabot always use a branch with the format `dependabot/:package_manager/:package_bump`. 

Dependabot PRs can be safely ignored since they do not introduce any new code would be scanned. This will greatly cut down on our use of actions minutes. Note that this is a new workflow, not an edit to the existing one, so PRs will have to be created in each repository that wants to use this new workflow.