### PR TITLE
fix code scanning workflow

### DIFF
--- a/workflow-templates/code-scanning-2021-06-08.yml
+++ b/workflow-templates/code-scanning-2021-06-08.yml
@@ -25,7 +25,7 @@ on:
 
 jobs:
   analyze:
-    if: ${{ !contains(github.ref, 'dependabot') }}
+    if: ${{ !contains(github.head_ref, 'dependabot') }}
     name: Analyze
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
I've tested this and it's working as-expected by using `head_ref`, rather than `ref`. The next step is to autogenerate PRs for this across the org.