### PR TITLE
Ignore terraform files in security scanning

### DIFF
--- a/config-files/codeql-config.yml
+++ b/config-files/codeql-config.yml
@@ -11,3 +11,4 @@ paths-ignore:
   - '**/*.test.ts'
   - '**/*.test.tsx'
   - '**/*.test.jsx'
+  - 'deploy/**/*.tf'


### PR DESCRIPTION
1. *.tf files are not supported by code scan yet. see [Supported languages and frameworks - CodeQL Documentation](https://codeql.github.com/docs/codeql-overview/supported-languages-and-frameworks/)
2. clear the warning "1 issue was detected with this workflow: Using on.push.paths-ignore can prevent Code Scanning annotating new alerts in your pull requests." when scanning PR contains tf file changes only. e.g., https://github.com/lifeomic/intervention-service/pull/75

reference: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#avoiding-unnecessary-scans-of-pull-requests