### PR TITLE
suggestion for updating the code-scanning template

### DIFF
--- a/workflow-templates/code-scanning-2022-06-29.properties.json
+++ b/workflow-templates/code-scanning-2022-06-29.properties.json
@@ -1,0 +1,13 @@
+{
+  "name": "General Use Code Scanning Workflow",
+  "description": "This workflow will run GitHub Code Scanning for PRs to master. This workflow will automatically detect scannable languages in your repository and run CodeQL queries against them.",
+  "iconName": "lifeomic",
+  "categories": [
+	  "C#",
+	  "C++",
+	  "Go",
+	  "Java",
+	  "JavaScript",
+	  "Python"	
+  ]
+}

--- a/workflow-templates/code-scanning-2022-06-29.yml
+++ b/workflow-templates/code-scanning-2022-06-29.yml
@@ -1,0 +1,60 @@
+# This workflow is inherited from our internal .github repo at https://github.com/lifeomic/.github/blob/master/workflow-templates/code-scanning-2022-06-29.yml
+# Setting up this workflow on the repository will perform a static scan for security issues using GitHub Code Scanning. 
+# Any findings for a repository can be found under the `Security` tab -> `Code Scanning Alerts`
+name: "CodeQL"
+
+on:
+  push:
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - test
+      - tests
+      - '**/test'
+      - '**/tests'
+      - '**/*.test.js'
+      - '**/*.test.ts'
+  pull_request:
+    branches:
+      - main
+      - master
+    paths-ignore:
+      - test
+      - tests
+      - '**/test'
+      - '**/tests'
+      - '**/*.test.js'
+      - '**/*.test.ts'
+
+jobs:
+  analyze:
+    if: ${{ !contains(github.head_ref, 'dependabot') }}
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      with:
+        # We must fetch at least the immediate parents so that if this is
+        # a pull request then we can checkout the head.
+        fetch-depth: 2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        config-file: lifeomic/.github/config-files/codeql-config.yml@master  # uses our config file from the lifeomic/.github repo
+        queries: +security-extended  # This will run all queries at https://github.com/github/codeql/:language/ql/src/codeql-suites/:language-security-extended.qls
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, it should be removed and replaced with custom build steps.
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v2
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
# Why
- codeql-action v1 is getting [deprecated](https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/)
- GitHub (and many other organizations) have [switched](https://github.com/github/renaming) from using `master` as the default branch name to `main` so just supporting that potential for us in the future by adding `main` to the `branches`